### PR TITLE
Add homepage with inventory type management

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A lightweight web-based inventory tracking application that works with Bluetooth barcode scanners and stores data in your browser's localStorage. Barcodes are rendered using [JsBarcode](https://github.com/lindell/JsBarcode).
 
 ## Features
+- Manage multiple inventory types
 - Add, update, and remove inventory items
 - Scan barcodes with a Bluetooth scanner or type them manually
 - Data is stored locally in your browser (no server required)
@@ -10,10 +11,11 @@ A lightweight web-based inventory tracking application that works with Bluetooth
 - Responsive layout for desktop and mobile
 
 ## Usage
-1. Open `index.html` in your browser or view the deployed GitHub Pages site.
-2. Scan a barcode into the **Scan Barcode** field or type it manually and press **Enter**.
-3. Fill in the item details and submit the form to add or update the item.
-4. Inventory items appear in the table where you can edit or delete them.
+1. Open `index.html` in your browser to see a list of inventory types.
+2. Create a new type or select an existing one to open its inventory page.
+3. On the inventory page scan a barcode into the **Scan Barcode** field or type it manually and press **Enter**.
+4. Fill in the item details and submit the form to add or update the item.
+5. Inventory items appear in the table where you can edit or delete them.
 
 ## Deployment
 This project can be hosted on GitHub Pages. In your repository settings, enable **GitHub Pages** for the `main` branch (or the branch containing this code) and select the root directory.

--- a/home.js
+++ b/home.js
@@ -1,0 +1,41 @@
+function loadTypes() {
+    const data = localStorage.getItem('inventoryTypes');
+    return data ? JSON.parse(data) : [];
+}
+
+function saveTypes(types) {
+    localStorage.setItem('inventoryTypes', JSON.stringify(types));
+}
+
+function renderTypes() {
+    const types = loadTypes();
+    const ul = document.getElementById('types');
+    ul.innerHTML = '';
+    types.forEach(t => {
+        const li = document.createElement('li');
+        const link = document.createElement('a');
+        link.href = `inventory.html?type=${encodeURIComponent(t)}`;
+        link.textContent = t;
+        li.appendChild(link);
+        ul.appendChild(li);
+    });
+}
+
+function addType(e) {
+    e.preventDefault();
+    const input = document.getElementById('typeName');
+    const name = input.value.trim();
+    if (!name) return;
+    let types = loadTypes();
+    if (!types.includes(name)) {
+        types.push(name);
+        saveTypes(types);
+        renderTypes();
+    }
+    input.value = '';
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    renderTypes();
+    document.getElementById('typeForm').addEventListener('submit', addType);
+});

--- a/index.html
+++ b/index.html
@@ -3,40 +3,25 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Inventory Tracker</title>
+    <title>Inventory Types</title>
     <link rel="stylesheet" href="style.css">
-    <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
 </head>
 <body>
-    <h1>Inventory Tracker</h1>
+    <h1>Inventory Types</h1>
 
-    <section id="scanner">
-        <label for="barcodeInput">Scan Barcode:</label>
-        <input type="text" id="barcodeInput" placeholder="Scan barcode" autofocus>
-    </section>
-
-    <section id="item-form-section">
-        <h2>Add / Update Item</h2>
-        <form id="itemForm">
-            <label>Name: <input type="text" id="itemName" required></label>
-            <label>Quantity: <input type="number" id="itemQty" required min="0"></label>
-            <label>Barcode: <input type="text" id="itemBarcode" required></label>
-            <label>Notes: <input type="text" id="itemNotes"></label>
-            <button type="submit">Add / Update</button>
+    <section id="add-type">
+        <h2>Add New Type</h2>
+        <form id="typeForm">
+            <label>Name: <input type="text" id="typeName" required></label>
+            <button type="submit">Add Type</button>
         </form>
     </section>
 
-    <section id="inventory">
-        <h2>Current Inventory</h2>
-        <table id="inventoryTable">
-            <thead>
-                <tr><th>Name</th><th>Qty</th><th>Barcode</th><th>Notes</th><th>Actions</th></tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
+    <section id="type-list">
+        <h2>Existing Types</h2>
+        <ul id="types"></ul>
     </section>
 
-    <script src="script.js"></script>
+    <script src="home.js"></script>
 </body>
 </html>

--- a/inventory.html
+++ b/inventory.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inventory Tracker</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
+</head>
+<body>
+    <h1 id="page-title">Inventory Tracker</h1>
+    <nav><a href="index.html">Back to Types</a></nav>
+
+    <section id="scanner">
+        <label for="barcodeInput">Scan Barcode:</label>
+        <input type="text" id="barcodeInput" placeholder="Scan barcode" autofocus>
+    </section>
+
+    <section id="item-form-section">
+        <h2>Add / Update Item</h2>
+        <form id="itemForm">
+            <label>Name: <input type="text" id="itemName" required></label>
+            <label>Quantity: <input type="number" id="itemQty" required min="0"></label>
+            <label>Barcode: <input type="text" id="itemBarcode" required></label>
+            <label>Notes: <input type="text" id="itemNotes"></label>
+            <button type="submit">Add / Update</button>
+        </form>
+    </section>
+
+    <section id="inventory">
+        <h2>Current Inventory</h2>
+        <table id="inventoryTable">
+            <thead>
+                <tr><th>Name</th><th>Qty</th><th>Barcode</th><th>Notes</th><th>Actions</th></tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+    </section>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,10 +1,21 @@
+const params = new URLSearchParams(location.search);
+const inventoryType = params.get('type') || 'default';
+const STORAGE_KEY = `inventoryItems_${inventoryType}`;
+
+document.addEventListener('DOMContentLoaded', () => {
+    const title = document.getElementById('page-title');
+    if (title) {
+        title.textContent = `Inventory Tracker - ${inventoryType}`;
+    }
+});
+
 function loadItems() {
-    const data = localStorage.getItem('inventoryItems');
+    const data = localStorage.getItem(STORAGE_KEY);
     return data ? JSON.parse(data) : [];
 }
 
 function saveItems(items) {
-    localStorage.setItem('inventoryItems', JSON.stringify(items));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
 }
 
 function renderItems() {
@@ -24,7 +35,6 @@ function renderItems() {
             </td>`;
         tbody.appendChild(tr);
     });
-    // render barcodes
     document.querySelectorAll('svg.barcode').forEach(svg => {
         JsBarcode(svg, svg.dataset.code, {displayValue: true});
     });

--- a/style.css
+++ b/style.css
@@ -39,3 +39,15 @@ section {
         margin-right: 1rem;
     }
 }
+#types {
+    list-style: none;
+    padding: 0;
+}
+
+#types li {
+    margin: 0.5rem 0;
+}
+
+nav {
+    margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- create a homepage that lists inventory types and allows adding new types
- move inventory UI to `inventory.html` and support multiple inventories via query parameter
- update JS to store items per type
- document new workflow in README
- basic styles for type list and navigation

## Testing
- `node -e "console.log('No tests available')"`


------
https://chatgpt.com/codex/tasks/task_b_6842ca901328832391402b62e75e74b9