### PR TITLE
Add editable inventory fields

### DIFF
--- a/inventory.html
+++ b/inventory.html
@@ -19,19 +19,17 @@
     <section id="item-form-section">
         <h2>Add / Update Item</h2>
         <form id="itemForm">
-            <label>Name: <input type="text" id="itemName" required></label>
-            <label>Quantity: <input type="number" id="itemQty" required min="0"></label>
-            <label>Barcode: <input type="text" id="itemBarcode" required></label>
-            <label>Notes: <input type="text" id="itemNotes"></label>
+            <div id="formFields"></div>
             <button type="submit">Add / Update</button>
         </form>
+        <button id="editFieldsBtn">Edit Fields</button>
     </section>
 
     <section id="inventory">
         <h2>Current Inventory</h2>
         <table id="inventoryTable">
             <thead>
-                <tr><th>Name</th><th>Qty</th><th>Barcode</th><th>Notes</th><th>Actions</th></tr>
+                <tr id="headerRow"></tr>
             </thead>
             <tbody>
             </tbody>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,58 @@
 const params = new URLSearchParams(location.search);
 const inventoryType = params.get('type') || 'default';
 const STORAGE_KEY = `inventoryItems_${inventoryType}`;
+const FIELD_KEY = `inventoryFields_${inventoryType}`;
+const DEFAULT_FIELDS = [
+    {key: 'name', label: 'Name'},
+    {key: 'quantity', label: 'Qty'},
+    {key: 'barcode', label: 'Barcode'},
+    {key: 'notes', label: 'Notes'}
+];
+
+function loadFields() {
+    const data = localStorage.getItem(FIELD_KEY);
+    if (data) return JSON.parse(data);
+    localStorage.setItem(FIELD_KEY, JSON.stringify(DEFAULT_FIELDS));
+    return DEFAULT_FIELDS.slice();
+}
+
+function saveFields(fields) {
+    localStorage.setItem(FIELD_KEY, JSON.stringify(fields));
+}
+
+function editFields() {
+    const current = loadFields();
+    const labels = current.map(f => f.label).join(',');
+    const input = prompt('Comma-separated field names (must include Barcode)', labels);
+    if (!input) return;
+    const newLabels = input.split(',').map(t => t.trim()).filter(t => t);
+    if (!newLabels.some(l => l.toLowerCase() === 'barcode')) {
+        alert('Fields must include Barcode');
+        return;
+    }
+    const newFields = [];
+    newLabels.forEach((label, idx) => {
+        if (current[idx]) {
+            newFields.push({key: current[idx].key, label});
+        } else {
+            const key = label.toLowerCase().replace(/\s+/g, '_');
+            newFields.push({key, label});
+        }
+    });
+    if (newFields.length < current.length) {
+        const removed = current.slice(newFields.length).map(f => f.key);
+        let items = loadItems();
+        items = items.map(it => {
+            removed.forEach(k => delete it[k]);
+            return it;
+        });
+        saveItems(items);
+    }
+    saveFields(newFields);
+    renderFormFields();
+    renderTableHeader();
+    renderItems();
+}
 
 document.addEventListener('DOMContentLoaded', () => {
     const title = document.getElementById('page-title');
@@ -18,43 +70,90 @@ function saveItems(items) {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
 }
 
+function renderFormFields() {
+    const fields = loadFields();
+    const container = document.getElementById('formFields');
+    if (!container) return;
+    container.innerHTML = '';
+    fields.forEach(f => {
+        const label = document.createElement('label');
+        label.textContent = f.label + ': ';
+        const input = document.createElement('input');
+        input.id = `field_${f.key}`;
+        input.type = f.key === 'quantity' ? 'number' : 'text';
+        if (f.key === 'quantity') input.min = '0';
+        if (f.key === 'barcode') input.required = true;
+        label.appendChild(input);
+        container.appendChild(label);
+    });
+}
+
+function renderTableHeader() {
+    const fields = loadFields();
+    const row = document.getElementById('headerRow');
+    if (!row) return;
+    row.innerHTML = '';
+    fields.forEach(f => {
+        const th = document.createElement('th');
+        th.textContent = f.label;
+        row.appendChild(th);
+    });
+    const actions = document.createElement('th');
+    actions.textContent = 'Actions';
+    row.appendChild(actions);
+}
+
 function renderItems() {
     const items = loadItems();
+    const fields = loadFields();
     const tbody = document.querySelector('#inventoryTable tbody');
     tbody.innerHTML = '';
     items.forEach(item => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `
-            <td>${item.name}</td>
-            <td>${item.quantity}</td>
-            <td><svg class="barcode" data-code="${item.barcode}"></svg></td>
-            <td>${item.notes || ''}</td>
-            <td>
-                <button data-edit="${item.barcode}">Edit</button>
-                <button data-delete="${item.barcode}">Delete</button>
-            </td>`;
+        fields.forEach(f => {
+            const td = document.createElement('td');
+            if (f.key === 'barcode') {
+                const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+                svg.classList.add('barcode');
+                svg.dataset.code = item[f.key] || '';
+                td.appendChild(svg);
+            } else {
+                td.textContent = item[f.key] || '';
+            }
+            tr.appendChild(td);
+        });
+        const act = document.createElement('td');
+        act.innerHTML = `<button data-edit="${item.barcode}">Edit</button> <button data-delete="${item.barcode}">Delete</button>`;
+        tr.appendChild(act);
         tbody.appendChild(tr);
     });
     document.querySelectorAll('svg.barcode').forEach(svg => {
-        JsBarcode(svg, svg.dataset.code, {displayValue: true});
+        const code = svg.dataset.code;
+        if (code) JsBarcode(svg, code, {displayValue: true});
     });
 }
 
 function addOrUpdateItem(e) {
     e.preventDefault();
-    const name = document.getElementById('itemName').value.trim();
-    const quantity = parseInt(document.getElementById('itemQty').value, 10) || 0;
-    const barcode = document.getElementById('itemBarcode').value.trim();
-    const notes = document.getElementById('itemNotes').value.trim();
-    if (!barcode) return;
+    const fields = loadFields();
+    const newItem = {};
+    fields.forEach(f => {
+        const val = document.getElementById(`field_${f.key}`).value.trim();
+        if (f.key === 'quantity') {
+            newItem[f.key] = parseInt(val, 10) || 0;
+        } else {
+            newItem[f.key] = val;
+        }
+    });
+    if (!newItem.barcode) return;
     let items = loadItems();
-    const existing = items.find(i => i.barcode === barcode);
+    const existing = items.find(i => i.barcode === newItem.barcode);
     if (existing) {
-        existing.name = name;
-        existing.quantity = quantity;
-        existing.notes = notes;
+        fields.forEach(f => {
+            existing[f.key] = newItem[f.key];
+        });
     } else {
-        items.push({name, quantity, barcode, notes});
+        items.push(newItem);
     }
     saveItems(items);
     renderItems();
@@ -67,10 +166,13 @@ function handleTableClick(e) {
     if (editBarcode) {
         const item = loadItems().find(i => i.barcode === editBarcode);
         if (item) {
-            document.getElementById('itemName').value = item.name;
-            document.getElementById('itemQty').value = item.quantity;
-            document.getElementById('itemBarcode').value = item.barcode;
-            document.getElementById('itemNotes').value = item.notes;
+            const fields = loadFields();
+            fields.forEach(f => {
+                const input = document.getElementById(`field_${f.key}`);
+                if (input) {
+                    input.value = item[f.key] || '';
+                }
+            });
         }
     } else if (delBarcode) {
         let items = loadItems().filter(i => i.barcode !== delBarcode);
@@ -84,15 +186,18 @@ function handleBarcodeInput(e) {
         e.preventDefault();
         const code = e.target.value.trim();
         if (code) {
-            document.getElementById('itemBarcode').value = code;
+            const barcodeInput = document.getElementById('field_barcode');
+            if (barcodeInput) barcodeInput.value = code;
             const item = loadItems().find(i => i.barcode === code);
+            const fields = loadFields();
             if (item) {
-                document.getElementById('itemName').value = item.name;
-                document.getElementById('itemQty').value = item.quantity;
-                document.getElementById('itemNotes').value = item.notes;
+                fields.forEach(f => {
+                    const input = document.getElementById(`field_${f.key}`);
+                    if (input) input.value = item[f.key] || '';
+                });
             } else {
                 document.getElementById('itemForm').reset();
-                document.getElementById('itemBarcode').value = code;
+                if (barcodeInput) barcodeInput.value = code;
             }
             e.target.value = '';
         }
@@ -100,8 +205,12 @@ function handleBarcodeInput(e) {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
+    renderFormFields();
+    renderTableHeader();
     renderItems();
     document.getElementById('itemForm').addEventListener('submit', addOrUpdateItem);
     document.querySelector('#inventoryTable tbody').addEventListener('click', handleTableClick);
     document.getElementById('barcodeInput').addEventListener('keydown', handleBarcodeInput);
+    const btn = document.getElementById('editFieldsBtn');
+    if (btn) btn.addEventListener('click', editFields);
 });


### PR DESCRIPTION
## Summary
- allow editing column names using an Edit Fields button
- dynamically render form inputs and table columns from stored field definitions
- persist per-type field configuration in localStorage

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_b_6842cef30e2c832381f01ab1aaa90c1e