### PR TITLE
Support multiline fields for items

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A lightweight web-based inventory tracking application that works with Bluetooth
 - Barcodes for each item are displayed in the table
 - Generate new item barcodes from the home page
 - Responsive layout for desktop and mobile
+- Default item fields include Name, Barcode, Amount, Material, Color, Store URL,
+  Price and Notes. Material and Notes support multiline input.
 
 ## Usage
 1. Open `index.html` in your browser to see a list of inventory types.

--- a/home.js
+++ b/home.js
@@ -84,7 +84,7 @@ function handleGenerateBarcode(e) {
     if (!type || !name) return;
     const items = loadItemsForType(type);
     const barcode = getNextBarcode(type);
-    items.push({name, quantity: 0, barcode, notes: ''});
+    items.push({name, amount: 0, barcode, notes: ''});
     saveItemsForType(type, items);
     const svg = document.getElementById('generatedBarcode');
     JsBarcode(svg, barcode, {displayValue: true});

--- a/script.js
+++ b/script.js
@@ -4,9 +4,13 @@ const STORAGE_KEY = `inventoryItems_${inventoryType}`;
 const FIELD_KEY = `inventoryFields_${inventoryType}`;
 const DEFAULT_FIELDS = [
     {key: 'name', label: 'Name'},
-    {key: 'quantity', label: 'Qty'},
     {key: 'barcode', label: 'Barcode'},
-    {key: 'notes', label: 'Notes'}
+    {key: 'amount', label: 'Amount'},
+    {key: 'material', label: 'Material', multiLine: true},
+    {key: 'color', label: 'Color'},
+    {key: 'store_url', label: 'Store URL'},
+    {key: 'price', label: 'Price'},
+    {key: 'notes', label: 'Notes', multiLine: true}
 ];
 
 function loadFields() {
@@ -33,7 +37,7 @@ function editFields() {
     const newFields = [];
     newLabels.forEach((label, idx) => {
         if (current[idx]) {
-            newFields.push({key: current[idx].key, label});
+            newFields.push({key: current[idx].key, label, multiLine: current[idx].multiLine});
         } else {
             const key = label.toLowerCase().replace(/\s+/g, '_');
             newFields.push({key, label});
@@ -78,10 +82,16 @@ function renderFormFields() {
     fields.forEach(f => {
         const label = document.createElement('label');
         label.textContent = f.label + ': ';
-        const input = document.createElement('input');
+        let input;
+        if (f.multiLine) {
+            input = document.createElement('textarea');
+            input.rows = 3;
+        } else {
+            input = document.createElement('input');
+            input.type = f.key === 'amount' ? 'number' : 'text';
+            if (f.key === 'amount') input.min = '0';
+        }
         input.id = `field_${f.key}`;
-        input.type = f.key === 'quantity' ? 'number' : 'text';
-        if (f.key === 'quantity') input.min = '0';
         if (f.key === 'barcode') input.required = true;
         label.appendChild(input);
         container.appendChild(label);
@@ -139,7 +149,7 @@ function addOrUpdateItem(e) {
     const newItem = {};
     fields.forEach(f => {
         const val = document.getElementById(`field_${f.key}`).value.trim();
-        if (f.key === 'quantity') {
+        if (f.key === 'amount') {
             newItem[f.key] = parseInt(val, 10) || 0;
         } else {
             newItem[f.key] = val;

--- a/style.css
+++ b/style.css
@@ -26,11 +26,16 @@ section {
     border: 1px solid #ddd;
     padding: 0.5rem;
     text-align: left;
+    white-space: pre-wrap;
 }
 
 .barcode {
     display: block;
     margin: 0 auto;
+}
+
+#itemForm textarea {
+    width: 100%;
 }
 
 @media (min-width: 600px) {


### PR DESCRIPTION
## Summary
- change default inventory fields to include Material and Color
- allow editing fields to keep multiline configuration
- render multiline fields with `<textarea>` inputs
- display multiline text in item table
- add Amount field after Barcode and update docs

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842d63a6bb483239fb77eb3133411fb