### PR TITLE
Fix layout issues and streamline pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+<div class="container">
     <h1>Inventory Types</h1>
 
     <section id="search-item">
@@ -43,6 +44,7 @@
         <svg id="generatedBarcode" class="barcode"></svg>
     </section>
 
+</div>
     <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
     <script src="home.js"></script>
 </body>

--- a/inventory.html
+++ b/inventory.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
 </head>
 <body>
+<div class="container">
     <h1 id="page-title">Inventory Tracker</h1>
     <nav><a href="index.html">Back to Types</a></nav>
 
@@ -16,6 +17,7 @@
         <input type="text" id="barcodeInput" placeholder="Scan barcode" autofocus>
     </section>
 
+    <div id="main-sections">
     <section id="inventory">
         <h2>Current Inventory</h2>
         <table id="inventoryTable">
@@ -35,6 +37,7 @@
             <button type="submit">Update Item</button>
         </form>
     </section>
+    </div>
 
     <section id="add-item-section">
         <h2>Add New Item</h2>
@@ -47,5 +50,6 @@
     </section>
 
     <script src="script.js"></script>
+</div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -4,6 +4,12 @@ body {
     margin: 0;
 }
 
+/* constrain page width on large screens */
+.container {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
 h1, h2 {
     text-align: center;
 }
@@ -66,11 +72,17 @@ nav {
     background-color: #ffffcc;
 }
 
-@media (min-width: 800px) {
-    #inventory,
-    #item-details {
-        display: inline-block;
-        width: 48%;
-        vertical-align: top;
-    }
+/* layout inventory table and details side by side on wide screens */
+#main-sections {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+}
+
+#main-sections > section {
+    flex: 1 1 300px;
+}
+
+#add-item-section {
+    flex-basis: 100%;
 }


### PR DESCRIPTION
## Summary
- wrap page content in a centered `.container` div
- group inventory table and selected item section in `#main-sections`
- use flexbox so the table and item details don't overlap
- keep add item section full width below the table

## Testing
- `tidy -q -errors index.html 2>&1 | head` *(fails: command not found)*
- `xmllint --html --noout index.html 2>&1 | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842e1bda4f483238d9742513bec92b1