### PR TITLE
Improve inventory layout

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,2 @@
 # TODO
 
-- The edit fields button isn't properly grouped with the table
-- Make the selected item be above the table
-- When an item is selected the info and input fields on the selected items are still a mess

--- a/inventory.html
+++ b/inventory.html
@@ -19,18 +19,6 @@
     </section>
 
     <div id="main-sections">
-    <section id="inventory">
-        <h2>Current Inventory</h2>
-        <table id="inventoryTable">
-            <thead>
-                <tr id="headerRow"></tr>
-            </thead>
-            <tbody>
-            </tbody>
-        </table>
-        <button id="printSelectedBtn">Print Selected Barcodes</button>
-    </section>
-
     <section id="item-details">
         <h2>Selected Item</h2>
         <div id="noSelection">Select an item to edit</div>
@@ -38,6 +26,21 @@
             <div id="selectedFields"></div>
             <button type="submit">Update Item</button>
         </form>
+    </section>
+
+    <section id="inventory">
+        <h2>Current Inventory</h2>
+        <div id="tableContainer">
+            <table id="inventoryTable">
+                <thead>
+                    <tr id="headerRow"></tr>
+                </thead>
+                <tbody>
+                </tbody>
+            </table>
+        </div>
+        <button id="printSelectedBtn">Print Selected Barcodes</button>
+        <button id="editFieldsBtn">Edit Fields</button>
     </section>
     </div>
 
@@ -48,7 +51,6 @@
             <button type="submit">Generate Barcode</button>
         </form>
         <svg id="newItemBarcode" class="barcode"></svg>
-        <button id="editFieldsBtn">Edit Fields</button>
     </section>
 
     <section id="invoice-upload">

--- a/style.css
+++ b/style.css
@@ -62,6 +62,11 @@ button {
     overflow: hidden;
 }
 
+#tableContainer {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
 #inventoryTable th, #inventoryTable td {
     border: 1px solid #ddd;
     padding: 0.5rem;
@@ -125,4 +130,13 @@ nav {
 
 #printSelectedBtn {
     margin-top: 0.5rem;
+}
+
+#selectedForm {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+#selectedForm label {
+    flex: 1 1 100%;
 }


### PR DESCRIPTION
## Summary
- show selected item form above the inventory table
- move **Edit Fields** button next to the table
- add scrolling container around the table
- clean up selected item form layout
- clear finished items from TODO

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6842fa5c0f008323a2460e22cf12edbc