### PR TITLE
Fix CSV import header mapping and restore delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,10 @@ The invoice upload feature now accepts comma separated value (`.csv`) files.
 Each row in the CSV should correspond to an inventory item and include column
 headers that match your field names (for example `name,barcode,amount`).
 When a CSV file is selected on the inventory page the items are parsed directly
-in the browser and added to your local inventory.
+in the browser and added to your local inventory. Header names are matched
+case-insensitively to your inventory fields and common synonyms like `quantity`
+or `code` are recognized automatically. If a barcode column is missing one will
+be generated for each imported row.
+
+The repository includes `mock_inventory_fabrics.csv` as a sample file that you
+can use to test the import feature.


### PR DESCRIPTION
## Summary
- improve CSV parsing: match headers case-insensitively and generate missing barcodes
- generate barcodes for imported rows in `script.js`
- document new behavior and sample CSV file in README

## Testing
- `node --check invoiceModule.js`
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_b_68430b1069f883239ee53868950016b6