### PR TITLE
Generate new barcode on CSV import

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ headers that match your field names (for example `name,barcode,amount`).
 When a CSV file is selected on the inventory page the items are parsed directly
 in the browser and added to your local inventory. Header names are matched
 case-insensitively to your inventory fields and common synonyms like `quantity`
-or `code` are recognized automatically. If a barcode column is missing one will
-be generated for each imported row.
+or `code` are recognized automatically. Any barcode values present in the CSV
+are ignored—the application always generates a new barcode for each imported
+row.
 
 The repository includes `mock_inventory_fabrics.csv` as a sample file that you
 can use to test the import feature.

--- a/invoiceModule.js
+++ b/invoiceModule.js
@@ -1,6 +1,7 @@
 // Parse a CSV file and add the resulting items to the inventory.
 // The first row must contain headers that match the inventory field keys
-// (e.g. "name", "barcode", "amount").
+// (e.g. "name", "barcode", "amount"). Any barcode values in the CSV are ignored
+// and new barcodes are generated during import.
 export async function handleFileUpload(file) {
   const items = await parseCSVFile(file);
   if (items && items.length) {
@@ -60,10 +61,8 @@ export function addItemsToInventory(items) {
   const fields = typeof loadFields === 'function' ? loadFields() : [];
   const barcodeField = fields.find(f => f.key === 'barcode');
   items.forEach(item => {
-    if (barcodeField && !item[barcodeField.key]) {
-      if (typeof getNextBarcode === 'function') {
-        item[barcodeField.key] = getNextBarcode();
-      }
+    if (barcodeField && typeof getNextBarcode === 'function') {
+      item[barcodeField.key] = getNextBarcode();
     }
     current.push(item);
   });

--- a/script.js
+++ b/script.js
@@ -341,9 +341,7 @@ function parseInvoiceCSV(text) {
         headers.forEach((key, idx) => {
             item[key] = cols[idx] || '';
         });
-        if (!item['barcode']) {
-            item['barcode'] = getNextBarcode();
-        }
+        item['barcode'] = getNextBarcode();
         items.push(item);
     }
     saveItems(items);


### PR DESCRIPTION
## Summary
- always generate barcode when importing CSV items
- document new behavior in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6844728dd6548323a93761f55d727831