### PR TITLE
Add SQL login section to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ The repository includes `mock_inventory_fabrics.csv` as a sample file that you
 can use to test the import feature.
 
 ## Server Configuration
-Create a `.env` file based on `.env.example` and provide your database connection details. Start the server with `npm start` and the front-end will read and write data through the exposed API.
+Create a `.env` file based on `.env.example` and provide your database connection details. You can also supply the connection information from the home page using the **Connect to Database** form. Start the server with `npm start` and the front-end will read and write data through the exposed API.

--- a/db.js
+++ b/db.js
@@ -1,29 +1,48 @@
 const sql = require('mssql');
 
-const config = {
-  user: process.env.DB_USER,
-  password: process.env.DB_PASS,
-  server: process.env.DB_HOST,
-  database: process.env.DB_NAME || 'inventory',
-  options: {
-    encrypt: true,
-    trustServerCertificate: true
-  }
-};
+let poolPromise = null;
+let currentConfig = null;
 
-const poolPromise = new sql.ConnectionPool(config)
-  .connect()
-  .then(pool => {
-    console.log('Connected to DB');
-    return pool;
-  })
-  .catch(err => {
-    console.error('DB Connection Failed', err);
-    throw err;
+function setConfig(cfg) {
+  currentConfig = {
+    user: cfg.user,
+    password: cfg.password,
+    server: cfg.server,
+    database: cfg.database || 'inventory',
+    options: {
+      encrypt: true,
+      trustServerCertificate: true
+    }
+  };
+  poolPromise = new sql.ConnectionPool(currentConfig)
+    .connect()
+    .then(pool => {
+      console.log('Connected to DB');
+      return pool;
+    })
+    .catch(err => {
+      console.error('DB Connection Failed', err);
+      throw err;
+    });
+  return poolPromise;
+}
+
+if (process.env.DB_USER && process.env.DB_PASS && process.env.DB_HOST) {
+  setConfig({
+    user: process.env.DB_USER,
+    password: process.env.DB_PASS,
+    server: process.env.DB_HOST,
+    database: process.env.DB_NAME
   });
+}
+
+async function getPool() {
+  if (!poolPromise) throw new Error('Database not configured');
+  return poolPromise;
+}
 
 async function init() {
-  const pool = await poolPromise;
+  const pool = await getPool();
   await pool.request().query(`
     IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='inventory_types' AND xtype='U')
     CREATE TABLE inventory_types (
@@ -46,4 +65,8 @@ async function init() {
   `);
 }
 
-module.exports = { sql, poolPromise, init };
+function isConfigured() {
+  return !!poolPromise;
+}
+
+module.exports = { sql, setConfig, getPool, init, isConfigured };

--- a/home.js
+++ b/home.js
@@ -107,6 +107,28 @@ function handleTypeListClick(e) {
     }
 }
 
+async function handleLogin(e) {
+    e.preventDefault();
+    const host = document.getElementById('dbHost').value.trim();
+    const user = document.getElementById('dbUser').value.trim();
+    const pass = document.getElementById('dbPass').value;
+    const database = document.getElementById('dbName').value.trim();
+    const msg = document.getElementById('loginMessage');
+    msg.textContent = '';
+    try {
+        const res = await fetch('/api/login', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({host, user, password: pass, database})
+        });
+        if (!res.ok) throw new Error();
+        msg.textContent = 'Connected to database';
+        renderTypes();
+    } catch {
+        msg.textContent = 'Failed to connect';
+    }
+}
+
 window.addEventListener('DOMContentLoaded', () => {
     renderTypes();
     document.getElementById('typeForm').addEventListener('submit', addType);
@@ -122,6 +144,10 @@ window.addEventListener('DOMContentLoaded', () => {
     const searchForm = document.getElementById('searchForm');
     if (searchForm) {
         searchForm.addEventListener('submit', handleSearch);
+    }
+    const loginForm = document.getElementById('loginForm');
+    if (loginForm) {
+        loginForm.addEventListener('submit', handleLogin);
     }
 });
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,30 @@
 <div class="container">
     <h1>Inventory Types</h1>
 
+    <section id="login-section">
+        <h2>Connect to Database</h2>
+        <form id="loginForm">
+            <label>Server
+                <input type="text" id="dbHost" placeholder="e.g. localhost" required>
+                <small>Address of your SQL server</small>
+            </label>
+            <label>Database
+                <input type="text" id="dbName" placeholder="inventory">
+                <small>Name of the database</small>
+            </label>
+            <label>Username
+                <input type="text" id="dbUser" required>
+                <small>Your SQL login name</small>
+            </label>
+            <label>Password
+                <input type="password" id="dbPass" required>
+                <small>Password for the SQL user</small>
+            </label>
+            <button type="submit">Connect</button>
+        </form>
+        <p id="loginMessage"></p>
+    </section>
+
     <section id="search-item">
         <h2>Search Item</h2>
         <form id="searchForm">

--- a/style.css
+++ b/style.css
@@ -140,3 +140,9 @@ nav {
 #selectedForm label {
     flex: 1 1 100%;
 }
+
+label small {
+    display: block;
+    font-size: 0.8em;
+    color: #555;
+}


### PR DESCRIPTION
## Summary
- allow configuring DB connection from a new login form
- expose `/api/login` endpoint and lazily init the DB
- make database module reconnectable
- hook login form up on client
- clarify login fields with helper text

## Testing
- `node -c server.js`
- `node -c db.js`
- `node -c home.js`


------
https://chatgpt.com/codex/tasks/task_b_685166031a408323ba56ca7f9d6272e1