### PR TITLE
Add configurable DB port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,5 @@ DB_HOST=localhost
 DB_USER=username
 DB_PASS=password
 DB_NAME=inventory
+DB_PORT=1433
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ can use to test the import feature.
 
 ## Server Configuration
 Create a `.env` file based on `.env.example` and provide your database connection details. You can also supply the connection information from the home page using the **Connect to Database** form. Start the server with `npm start` and the front-end will read and write data through the exposed API.
+
+The configuration accepts an optional `DB_PORT` (default `1433`). Include this value in your `.env` file or the login form if your SQL server listens on a non-standard port.

--- a/db.js
+++ b/db.js
@@ -8,6 +8,7 @@ function setConfig(cfg) {
     user: cfg.user,
     password: cfg.password,
     server: cfg.server,
+    port: cfg.port,
     database: cfg.database || 'inventory',
     options: {
       encrypt: true,
@@ -32,7 +33,8 @@ if (process.env.DB_USER && process.env.DB_PASS && process.env.DB_HOST) {
     user: process.env.DB_USER,
     password: process.env.DB_PASS,
     server: process.env.DB_HOST,
-    database: process.env.DB_NAME
+    database: process.env.DB_NAME,
+    port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : undefined
   });
 }
 

--- a/home.js
+++ b/home.js
@@ -110,6 +110,7 @@ function handleTypeListClick(e) {
 async function handleLogin(e) {
     e.preventDefault();
     const host = document.getElementById('dbHost').value.trim();
+    const portValue = document.getElementById('dbPort').value.trim();
     const user = document.getElementById('dbUser').value.trim();
     const pass = document.getElementById('dbPass').value;
     const database = document.getElementById('dbName').value.trim();
@@ -119,7 +120,7 @@ async function handleLogin(e) {
         const res = await fetch('/api/login', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({host, user, password: pass, database})
+            body: JSON.stringify({host, user, password: pass, database, port: portValue ? Number(portValue) : undefined})
         });
         if (!res.ok) throw new Error();
         msg.textContent = 'Connected to database';

--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
                 <input type="text" id="dbHost" placeholder="e.g. localhost" required>
                 <small>Address of your SQL server</small>
             </label>
+            <label>Port
+                <input type="number" id="dbPort" placeholder="1433">
+                <small>Port for the SQL server</small>
+            </label>
             <label>Database
                 <input type="text" id="dbName" placeholder="inventory">
                 <small>Name of the database</small>

--- a/server.js
+++ b/server.js
@@ -7,12 +7,12 @@ const app = express();
 app.use(express.json({limit: '2mb'}));
 
 app.post('/api/login', async (req, res) => {
-  const { host, user, password, database } = req.body || {};
+  const { host, user, password, database, port } = req.body || {};
   if (!host || !user || !password) {
     return res.status(400).json({ error: 'Missing credentials' });
   }
   try {
-    await db.setConfig({ server: host, user, password, database });
+    await db.setConfig({ server: host, user, password, database, port });
     await db.init();
     res.json({ success: true });
   } catch (err) {


### PR DESCRIPTION
## Summary
- allow specifying DB port via `.env` and login form
- pass port option from server to database module
- extend login form with port field
- document DB_PORT usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6851b006be288323975f09ff08769794