### PR TITLE
Use external server address and local DB

### DIFF
--- a/db.js
+++ b/db.js
@@ -28,13 +28,13 @@ function setConfig(cfg) {
   return poolPromise;
 }
 
-if (process.env.DB_USER && process.env.DB_PASS && process.env.DB_HOST) {
+if (process.env.DB_USER && process.env.DB_PASS) {
   setConfig({
     user: process.env.DB_USER,
     password: process.env.DB_PASS,
-    server: process.env.DB_HOST,
+    server: 'localhost',
     database: process.env.DB_NAME,
-    port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : undefined
+    port: 5432
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -14,12 +14,12 @@
         <h2>Connect to Database</h2>
         <form id="loginForm">
             <label>Server
-                <input type="text" id="dbHost" placeholder="e.g. localhost" required>
-                <small>Address of your SQL server</small>
+                <input type="text" id="serverHost" placeholder="e.g. 192.168.1.100" required>
+                <small>Address of the Node server</small>
             </label>
             <label>Port
-                <input type="number" id="dbPort" placeholder="1433">
-                <small>Port for the SQL server</small>
+                <input type="number" id="serverPort" placeholder="3000">
+                <small>Port for the Node server</small>
             </label>
             <label>Database
                 <input type="text" id="dbName" placeholder="inventory">

--- a/migration.js
+++ b/migration.js
@@ -1,14 +1,16 @@
+const API_BASE_URL = localStorage.getItem('apiBaseUrl') || '';
+
 export async function migrateLocalData() {
   const types = JSON.parse(localStorage.getItem('inventoryTypes') || '[]');
   for (const type of types) {
-    await fetch('/api/types', {
+    await fetch(`${API_BASE_URL}/api/types`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({name: type})
     });
     const items = JSON.parse(localStorage.getItem(`inventoryItems_${type}`) || '[]');
     for (const it of items) {
-      await fetch(`/api/items/${encodeURIComponent(type)}`, {
+      await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(type)}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(it)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "inventory-system-server",
       "version": "1.0.0",
       "dependencies": {
+        "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^4.18.2",
         "mssql": "^11.0.1",
@@ -539,6 +540,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -1316,6 +1330,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dotenv": "^16.5.0",
     "express": "^4.18.2",
     "mssql": "^11.0.1",
-    "node-fetch": "^2.6.1"
+    "node-fetch": "^2.6.1",
+    "cors": "^2.8.5"
   }
 }

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 const params = new URLSearchParams(location.search);
 const inventoryType = params.get('type') || 'default';
+const API_BASE_URL = localStorage.getItem('apiBaseUrl') || '';
 const STORAGE_KEY = `inventoryItems_${inventoryType}`;
 const FIELD_KEY = `inventoryFields_${inventoryType}`;
 const DEFAULT_FIELDS = [
@@ -80,13 +81,13 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 async function loadItems() {
-    const res = await fetch(`/api/items/${encodeURIComponent(inventoryType)}`);
+    const res = await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(inventoryType)}`);
     if (!res.ok) return [];
     return await res.json();
 }
 
 async function saveItem(item) {
-    await fetch(`/api/items/${encodeURIComponent(inventoryType)}`, {
+    await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(inventoryType)}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(item)
@@ -94,7 +95,7 @@ async function saveItem(item) {
 }
 
 async function updateItem(barcode, item) {
-    await fetch(`/api/items/${encodeURIComponent(inventoryType)}/${encodeURIComponent(barcode)}`, {
+    await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(inventoryType)}/${encodeURIComponent(barcode)}`, {
         method: 'PUT',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(item)
@@ -102,7 +103,7 @@ async function updateItem(barcode, item) {
 }
 
 async function deleteItem(barcode) {
-    await fetch(`/api/items/${encodeURIComponent(inventoryType)}/${encodeURIComponent(barcode)}`, { method: 'DELETE' });
+    await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(inventoryType)}/${encodeURIComponent(barcode)}`, { method: 'DELETE' });
 }
 
 let nextBarcodeCounter = null;

--- a/server.js
+++ b/server.js
@@ -1,18 +1,20 @@
 require('dotenv').config();
 const express = require('express');
 const fetch = require('node-fetch');
+const cors = require('cors');
 const db = require('./db');
 
 const app = express();
+app.use(cors());
 app.use(express.json({limit: '2mb'}));
 
 app.post('/api/login', async (req, res) => {
-  const { host, user, password, database, port } = req.body || {};
-  if (!host || !user || !password) {
+  const { user, password, database } = req.body || {};
+  if (!user || !password) {
     return res.status(400).json({ error: 'Missing credentials' });
   }
   try {
-    await db.setConfig({ server: host, user, password, database, port });
+    await db.setConfig({ server: 'localhost', port: 5432, user, password, database });
     await db.init();
     res.json({ success: true });
   } catch (err) {


### PR DESCRIPTION
## Summary
- allow specifying external Node server address via login form
- store API base URL to use across pages
- connect server to local database on `localhost:5432`
- enable CORS support
- add cors dependency

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6851ba9e5f6c832394534d2e40802791