### PR TITLE
Use unique API base URL variable

### DIFF
--- a/home.js
+++ b/home.js
@@ -1,13 +1,13 @@
-const API_BASE_URL = localStorage.getItem('apiBaseUrl') || '';
+let apiBaseUrl = localStorage.getItem('apiBaseUrl') || '';
 
 async function loadTypes() {
-    const res = await fetch(`${API_BASE_URL}/api/types`);
+    const res = await fetch(`${apiBaseUrl}/api/types`);
     if (!res.ok) return [];
     return await res.json();
 }
 
 async function saveType(name) {
-    await fetch(`${API_BASE_URL}/api/types`, {
+    await fetch(`${apiBaseUrl}/api/types`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({name})
@@ -45,13 +45,13 @@ async function addType(e) {
 }
 
 async function loadItemsForType(type) {
-    const res = await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(type)}`);
+    const res = await fetch(`${apiBaseUrl}/api/items/${encodeURIComponent(type)}`);
     if (!res.ok) return [];
     return await res.json();
 }
 
 async function saveItemForType(type, item) {
-    await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(type)}`, {
+    await fetch(`${apiBaseUrl}/api/items/${encodeURIComponent(type)}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(item)
@@ -98,7 +98,7 @@ async function handleGenerateBarcode(e) {
 
 async function deleteType(name) {
     if (!confirm(`Delete type "${name}" and all its data?`)) return;
-    await fetch(`${API_BASE_URL}/api/types/${encodeURIComponent(name)}`, { method: 'DELETE' });
+    await fetch(`${apiBaseUrl}/api/types/${encodeURIComponent(name)}`, { method: 'DELETE' });
     renderTypes();
 }
 
@@ -111,17 +111,28 @@ function handleTypeListClick(e) {
 
 async function handleLogin(e) {
     e.preventDefault();
-    const serverHost = document.getElementById('serverHost').value.trim();
-    const serverPort = document.getElementById('serverPort').value.trim();
-    API_BASE_URL = serverPort ? `http://${serverHost}:${serverPort}` : `http://${serverHost}`;
-    localStorage.setItem('apiBaseUrl', API_BASE_URL);
-    const user = document.getElementById('dbUser').value.trim();
-    const pass = document.getElementById('dbPass').value;
-    const database = document.getElementById('dbName').value.trim();
+    const hostEl = document.getElementById('serverHost');
+    const portEl = document.getElementById('serverPort');
+    const userEl = document.getElementById('dbUser');
+    const passEl = document.getElementById('dbPass');
+    const dbEl = document.getElementById('dbName');
     const msg = document.getElementById('loginMessage');
+
+    if (!hostEl || !portEl || !userEl || !passEl || !dbEl) {
+        console.error('Login form elements missing');
+        return;
+    }
+
+    const serverHost = hostEl.value.trim();
+    const serverPort = portEl.value.trim();
+    apiBaseUrl = serverPort ? `http://${serverHost}:${serverPort}` : `http://${serverHost}`;
+    localStorage.setItem('apiBaseUrl', apiBaseUrl);
+    const user = userEl.value.trim();
+    const pass = passEl.value;
+    const database = dbEl.value.trim();
     msg.textContent = '';
     try {
-        const res = await fetch(`${API_BASE_URL}/api/login`, {
+        const res = await fetch(`${apiBaseUrl}/api/login`, {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({user, password: pass, database})
@@ -135,7 +146,7 @@ async function handleLogin(e) {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
-    const urlMatch = API_BASE_URL.match(/^https?:\/\/([^:]+)(?::(\d+))?/);
+    const urlMatch = apiBaseUrl.match(/^https?:\/\/([^:]+)(?::(\d+))?/);
     if (urlMatch) {
         document.getElementById('serverHost').value = urlMatch[1];
         if (urlMatch[2]) document.getElementById('serverPort').value = urlMatch[2];

--- a/migration.js
+++ b/migration.js
@@ -1,16 +1,16 @@
-const API_BASE_URL = localStorage.getItem('apiBaseUrl') || '';
+let apiBaseUrl = localStorage.getItem('apiBaseUrl') || '';
 
 export async function migrateLocalData() {
   const types = JSON.parse(localStorage.getItem('inventoryTypes') || '[]');
   for (const type of types) {
-    await fetch(`${API_BASE_URL}/api/types`, {
+    await fetch(`${apiBaseUrl}/api/types`, {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({name: type})
     });
     const items = JSON.parse(localStorage.getItem(`inventoryItems_${type}`) || '[]');
     for (const it of items) {
-      await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(type)}`, {
+      await fetch(`${apiBaseUrl}/api/items/${encodeURIComponent(type)}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(it)

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 const params = new URLSearchParams(location.search);
 const inventoryType = params.get('type') || 'default';
-const API_BASE_URL = localStorage.getItem('apiBaseUrl') || '';
+let apiBaseUrl = localStorage.getItem('apiBaseUrl') || '';
 const STORAGE_KEY = `inventoryItems_${inventoryType}`;
 const FIELD_KEY = `inventoryFields_${inventoryType}`;
 const DEFAULT_FIELDS = [
@@ -81,13 +81,13 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 async function loadItems() {
-    const res = await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(inventoryType)}`);
+    const res = await fetch(`${apiBaseUrl}/api/items/${encodeURIComponent(inventoryType)}`);
     if (!res.ok) return [];
     return await res.json();
 }
 
 async function saveItem(item) {
-    await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(inventoryType)}`, {
+    await fetch(`${apiBaseUrl}/api/items/${encodeURIComponent(inventoryType)}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(item)
@@ -95,7 +95,7 @@ async function saveItem(item) {
 }
 
 async function updateItem(barcode, item) {
-    await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(inventoryType)}/${encodeURIComponent(barcode)}`, {
+    await fetch(`${apiBaseUrl}/api/items/${encodeURIComponent(inventoryType)}/${encodeURIComponent(barcode)}`, {
         method: 'PUT',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify(item)
@@ -103,7 +103,7 @@ async function updateItem(barcode, item) {
 }
 
 async function deleteItem(barcode) {
-    await fetch(`${API_BASE_URL}/api/items/${encodeURIComponent(inventoryType)}/${encodeURIComponent(barcode)}`, { method: 'DELETE' });
+    await fetch(`${apiBaseUrl}/api/items/${encodeURIComponent(inventoryType)}/${encodeURIComponent(barcode)}`, { method: 'DELETE' });
 }
 
 let nextBarcodeCounter = null;


### PR DESCRIPTION
## Summary
- rename `API_BASE_URL` to `apiBaseUrl` so it doesn't conflict with any global constants
- keep login and migration scripts in sync with the new variable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6851bc1c687483238162e06432000141